### PR TITLE
Fix emote search insertion (#81)

### DIFF
--- a/discord/addon/core/core.js
+++ b/discord/addon/core/core.js
@@ -19,7 +19,7 @@ cssMap['/extracss-pure.css'] = require('raw-loader!./extracss-pure.css');
 cssMap['/extracss-webkit.css'] = require('raw-loader!./extracss-webkit.css');
 
 function getChatInputTextarea() {
-    var sendbox = utils.getElementsByClassName('channel-textarea-inner');
+    var sendbox = utils.getElementsByClassName('channel-text-area-default');
     if(sendbox.length === 0) {
         return null;
     }


### PR DESCRIPTION
Recent update changed the identifier, and now BPM cannot find the textarea he needs to auto-insert the emote into.